### PR TITLE
Persistence converters

### DIFF
--- a/.github/workflows/test-coverage.yaml
+++ b/.github/workflows/test-coverage.yaml
@@ -30,6 +30,6 @@ jobs:
       - name: Test
         run: flutter test --coverage
       - name: Upload report
-        uses: codecov/codecov-action@v2
+        uses: codecov/codecov-action@v3
         with:
           flags: ${{ matrix.project }}

--- a/fast_rx_persistence/CHANGELOG.md
+++ b/fast_rx_persistence/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.0
+- BREAKING: Replaces `decode` and `encode` parameters with a `converter` paramerter that takes a `FastRxPersistenceConverter`. The simplest migration is to pass in an `InlineConverter` with `fromStore` and `toStore` parameters.
+- Adds `EnumStringConverter` and `EnumIntConverter` for convenience
+
 ## 0.1.5
 - Updated `fast_rx` to 0.4.0
 

--- a/fast_rx_persistence/README.md
+++ b/fast_rx_persistence/README.md
@@ -41,8 +41,10 @@ void example() {
       // Otherwise the store passed into [FastRxPersistence.init] will be
       // used.
       store: Store(),
-      decode: int.parse,
-      encode: (value) => value.toString(),
+      converter: InlineConverter(
+        fromStore: int.parse,
+        toStore: (value) => value.toString(),
+      ),
     );
 
   // Saves the value to the store as a string

--- a/fast_rx_persistence/lib/fast_rx_persistence.dart
+++ b/fast_rx_persistence/lib/fast_rx_persistence.dart
@@ -2,4 +2,5 @@ library fast_rx_persistence;
 
 export 'src/exceptions.dart';
 export 'src/fast_rx_persistence_base.dart';
+export 'src/fast_rx_persistence_converter.dart';
 export 'src/fast_rx_persistence_interface.dart';

--- a/fast_rx_persistence/lib/src/fast_rx_persistence_base.dart
+++ b/fast_rx_persistence/lib/src/fast_rx_persistence_base.dart
@@ -1,4 +1,5 @@
 import 'package:fast_rx_persistence/src/exceptions.dart';
+import 'package:fast_rx_persistence/src/fast_rx_persistence_converter.dart';
 import 'package:fast_rx_persistence/src/fast_rx_persistence_interface.dart';
 import 'package:fast_rx/fast_rx.dart';
 import 'package:flutter/foundation.dart';
@@ -59,18 +60,14 @@ extension RxPersistenceExtension<T> on RxValue<T> {
   void persist<I>(
     String key, {
     FastRxPersistenceInterface? store,
-    T Function(I value)? decode,
-    I Function(T value)? encode,
+    FastRxPersistenceConverter<T, I>? converter,
   }) {
-    assert(
-      (decode == null && encode == null) || (decode != null && encode != null),
-    );
-
     final interface = store ?? FastRxPersistence.store;
 
     final storeValue = interface.get(key);
     if (storeValue != null) {
-      final transformedValue = decode?.call(storeValue as I) ?? storeValue as T;
+      final transformedValue =
+          converter?.fromStore(storeValue as I) ?? storeValue as T;
 
       if (this is RxObject) {
         // ignore: invalid_use_of_protected_member
@@ -82,7 +79,7 @@ extension RxPersistenceExtension<T> on RxValue<T> {
     }
 
     stream.listen((value) {
-      final storeValue = encode?.call(value) ?? value as I;
+      final storeValue = converter?.toStore(value) ?? value as I;
       interface.set(key, storeValue);
     });
   }

--- a/fast_rx_persistence/lib/src/fast_rx_persistence_converter.dart
+++ b/fast_rx_persistence/lib/src/fast_rx_persistence_converter.dart
@@ -18,13 +18,13 @@ class InlineConverter<T, I> extends FastRxPersistenceConverter<T, I> {
   /// - [fromStore]: Convert the value read from the store
   /// - [toStore]: Convert the value written to the store
   const InlineConverter({
-    required T Function(I) fromStore,
-    required I Function(T) toStore,
+    required T Function(I value) fromStore,
+    required I Function(T value) toStore,
   })  : _fromStoreInline = fromStore,
         _toStoreInline = toStore;
 
-  final T Function(I) _fromStoreInline;
-  final I Function(T) _toStoreInline;
+  final T Function(I value) _fromStoreInline;
+  final I Function(T value) _toStoreInline;
 
   @override
   T fromStore(I value) => _fromStoreInline(value);

--- a/fast_rx_persistence/lib/src/fast_rx_persistence_converter.dart
+++ b/fast_rx_persistence/lib/src/fast_rx_persistence_converter.dart
@@ -1,0 +1,68 @@
+/// Convert a value to/from a [FastRxPersistenceInterface]
+/// - [T] is the type of the value read from the store
+/// - [I] is the type of the value written to the store
+abstract class FastRxPersistenceConverter<T, I> {
+  /// Constructor
+  const FastRxPersistenceConverter();
+
+  /// Convert the value read from the store
+  T fromStore(I value);
+
+  /// Convert the value written to the store
+  I toStore(T value);
+}
+
+/// Conveniently create a [FastRxPersistenceConverter] inline
+class InlineConverter<T, I> extends FastRxPersistenceConverter<T, I> {
+  /// Constructor
+  /// - [fromStore]: Convert the value read from the store
+  /// - [toStore]: Convert the value written to the store
+  const InlineConverter({
+    required T Function(I) fromStore,
+    required I Function(T) toStore,
+  })  : _fromStoreInline = fromStore,
+        _toStoreInline = toStore;
+
+  final T Function(I) _fromStoreInline;
+  final I Function(T) _toStoreInline;
+
+  @override
+  T fromStore(I value) => _fromStoreInline(value);
+
+  @override
+  I toStore(T value) => _toStoreInline(value);
+}
+
+/// Converter between [Enum] and [I]
+abstract class EnumConverter<T extends Enum, I>
+    extends FastRxPersistenceConverter<T, I> {
+  /// Constructor
+  const EnumConverter(this.values);
+
+  /// Then enum values
+  final List<T> values;
+}
+
+/// Converter between [Enum] and [String]
+class EnumStringConverter<T extends Enum> extends EnumConverter<T, String> {
+  /// Constructor
+  const EnumStringConverter(super.values);
+
+  @override
+  T fromStore(String value) => values.byName(value);
+
+  @override
+  String toStore(T value) => value.name;
+}
+
+/// Converter between [Enum] and [int]
+class EnumIntConverter<T extends Enum> extends EnumConverter<T, int> {
+  /// Constructor
+  const EnumIntConverter(super.values);
+
+  @override
+  T fromStore(int value) => values[value];
+
+  @override
+  int toStore(T value) => value.index;
+}

--- a/fast_rx_persistence/pubspec.yaml
+++ b/fast_rx_persistence/pubspec.yaml
@@ -1,6 +1,6 @@
 name: fast_rx_persistence
 description: An interface for implementing fast_rx key/value store persistence
-version: 0.1.5
+version: 0.2.0
 homepage: https://github.com/Rexios80/fast_ui/tree/master/fast_rx_persistence
 
 environment:

--- a/fast_rx_persistence/readme/usage.dart
+++ b/fast_rx_persistence/readme/usage.dart
@@ -1,6 +1,11 @@
 import 'package:fast_rx/fast_rx.dart';
 import 'package:fast_rx_persistence/fast_rx_persistence.dart';
 
+final intStringConverter = InlineConverter(
+  fromStore: int.parse,
+  toStore: (value) => value.toString(),
+);
+
 void example() {
   FastRxPersistence.init(Store());
 
@@ -21,8 +26,7 @@ void example() {
       // Otherwise the store passed into [FastRxPersistence.init] will be
       // used.
       store: Store(),
-      decode: int.parse,
-      encode: (value) => value.toString(),
+      converter: intStringConverter,
     );
 
   // Saves the value to the store as a string

--- a/fast_rx_persistence/readme/usage.dart
+++ b/fast_rx_persistence/readme/usage.dart
@@ -1,11 +1,6 @@
 import 'package:fast_rx/fast_rx.dart';
 import 'package:fast_rx_persistence/fast_rx_persistence.dart';
 
-final intStringConverter = InlineConverter(
-  fromStore: int.parse,
-  toStore: (value) => value.toString(),
-);
-
 void example() {
   FastRxPersistence.init(Store());
 
@@ -26,7 +21,10 @@ void example() {
       // Otherwise the store passed into [FastRxPersistence.init] will be
       // used.
       store: Store(),
-      converter: intStringConverter,
+      converter: InlineConverter(
+        fromStore: int.parse,
+        toStore: (value) => value.toString(),
+      ),
     );
 
   // Saves the value to the store as a string

--- a/fast_rx_persistence/test/fast_rx_persistence_test.dart
+++ b/fast_rx_persistence/test/fast_rx_persistence_test.dart
@@ -45,21 +45,13 @@ void main() {
       ),
     );
 
-    // Both decode and encode must be specified if one of them is
-    expect(
-      () => 0.rx.persist<String>('key', decode: (value) => int.parse(value)),
-      throwsA(isA<AssertionError>()),
-    );
-    expect(
-      () => 0.rx.persist<String>('key', encode: (value) => value.toString()),
-      throwsA(isA<AssertionError>()),
-    );
-
     final rx = <int>[].rx
       ..persist<List<String>>(
         'key',
-        decode: (value) => value.map(int.parse).toList(),
-        encode: (value) => value.map((e) => e.toString()).toList(),
+        converter: InlineConverter(
+          fromStore: (value) => value.map(int.parse).toList(),
+          toStore: (value) => value.map((e) => e.toString()).toList(),
+        ),
       );
 
     expect(listEquals(rx, [17]), isTrue);

--- a/fast_rx_persistence/test/fast_rx_persistence_test.dart
+++ b/fast_rx_persistence/test/fast_rx_persistence_test.dart
@@ -64,6 +64,27 @@ void main() {
       isTrue,
     );
   });
+
+  test('Enum transformation', () async {
+    FastRxPersistence.init(Store(values: {'key0': 'zero', 'key1': 1}));
+
+    final rx0 = TestEnum.two.rx
+      ..persist('key0', converter: const EnumStringConverter(TestEnum.values));
+    final rx1 = TestEnum.two.rx
+      ..persist('key1', converter: const EnumIntConverter(TestEnum.values));
+
+    expect(rx0.value, TestEnum.zero);
+    expect(rx1.value, TestEnum.one);
+
+    rx0.value = TestEnum.two;
+    rx1.value = TestEnum.two;
+
+    // Wait for the stream to emit the update
+    await Future.delayed(Duration.zero);
+
+    expect(FastRxPersistence.store.get('key0'), 'two');
+    expect(FastRxPersistence.store.get('key1'), 2);
+  });
 }
 
 class Store extends FastRxPersistenceInterface {
@@ -80,4 +101,10 @@ class Store extends FastRxPersistenceInterface {
   void set(String key, Object? value) {
     _store[key] = value;
   }
+}
+
+enum TestEnum {
+  zero,
+  one,
+  two,
 }

--- a/fast_rx_persistence/test/fast_rx_persistence_test.dart
+++ b/fast_rx_persistence/test/fast_rx_persistence_test.dart
@@ -66,24 +66,24 @@ void main() {
   });
 
   test('Enum transformation', () async {
-    FastRxPersistence.init(Store(values: {'key0': 'zero', 'key1': 1}));
+    FastRxPersistence.init(Store(values: {'key0': 'zero', 'key1': 0}));
 
-    final rx0 = TestEnum.two.rx
+    final rx0 = TestEnum.one.rx
       ..persist('key0', converter: const EnumStringConverter(TestEnum.values));
-    final rx1 = TestEnum.two.rx
+    final rx1 = TestEnum.one.rx
       ..persist('key1', converter: const EnumIntConverter(TestEnum.values));
 
     expect(rx0.value, TestEnum.zero);
-    expect(rx1.value, TestEnum.one);
+    expect(rx1.value, TestEnum.zero);
 
-    rx0.value = TestEnum.two;
-    rx1.value = TestEnum.two;
+    rx0.value = TestEnum.one;
+    rx1.value = TestEnum.one;
 
     // Wait for the stream to emit the update
     await Future.delayed(Duration.zero);
 
-    expect(FastRxPersistence.store.get('key0'), 'two');
-    expect(FastRxPersistence.store.get('key1'), 2);
+    expect(FastRxPersistence.store.get('key0'), 'one');
+    expect(FastRxPersistence.store.get('key1'), 1);
   });
 }
 
@@ -106,5 +106,4 @@ class Store extends FastRxPersistenceInterface {
 enum TestEnum {
   zero,
   one,
-  two,
 }

--- a/fast_ui/example/lib/examples/fast_rx_persistence_example.dart
+++ b/fast_ui/example/lib/examples/fast_rx_persistence_example.dart
@@ -26,6 +26,12 @@ class FastRxPersistenceExample extends StatelessWidget {
         child: ListView(
           padding: const EdgeInsets.all(20),
           children: <Widget>[
+            Text(
+              'Reload the page to see the persisted values',
+              textAlign: TextAlign.center,
+              style: context.textTheme.titleMedium,
+            ),
+            const SizedBox(height: 20),
             const Text('Reactive int preference:'),
             FastBuilder(
               () => Text(

--- a/fast_ui/example/lib/examples/fast_rx_persistence_example.dart
+++ b/fast_ui/example/lib/examples/fast_rx_persistence_example.dart
@@ -10,8 +10,10 @@ class FastRxPersistenceExample extends StatelessWidget {
   final transformedPref = <int>[].rx
     ..persist<List<String>>(
       'transformed',
-      decode: (value) => value.map(int.parse).toList(),
-      encode: (value) => value.map((e) => e.toString()).toList(),
+      converter: InlineConverter(
+        fromStore: (value) => value.map(int.parse).toList(),
+        toStore: (value) => value.map((e) => e.toString()).toList(),
+      ),
     );
 
   FastRxPersistenceExample({super.key});

--- a/fast_ui/example/lib/main.dart
+++ b/fast_ui/example/lib/main.dart
@@ -17,30 +17,16 @@ void main() async {
 
   await FastRxSharedPreferences.init();
 
-  runApp(const FastUiExampleApp());
+  runApp(const FastUiExamplePreview());
 }
 
-class FastUiExampleApp extends StatelessWidget {
-  const FastUiExampleApp({super.key});
+class FastUiExamplePreview extends StatelessWidget {
+  const FastUiExamplePreview({super.key});
 
   @override
   Widget build(BuildContext context) {
     return DevicePreview(
-      builder: (context) => MaterialApp(
-        useInheritedMediaQuery: true,
-        locale: DevicePreview.locale(context),
-        builder: DevicePreview.appBuilder,
-        // Initialize both FastNav and FastOverlays in one line
-        navigatorKey: FastNav.init(FastOverlays.init()),
-        navigatorObservers: [FastNavObserver()],
-        title: 'fast_ui Example',
-        theme: ThemeData.light(),
-        darkTheme: ThemeData.dark(),
-        onGenerateRoute: (settings) => FastNav.generateAnonymousRoute(
-          settings: settings,
-          page: const FastUiExample(),
-        ),
-      ),
+      builder: (_) => const FastUiExampleApp(),
       tools: [
         ToolPanelSection(
           title: 'Links',
@@ -67,13 +53,55 @@ class FastUiExampleApp extends StatelessWidget {
   }
 }
 
+final themeMode = ThemeMode.light.rx;
+
+class FastUiExampleApp extends StatelessWidget {
+  const FastUiExampleApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return FastBuilder(
+      () => MaterialApp(
+        useInheritedMediaQuery: true,
+        locale: DevicePreview.locale(context),
+        builder: DevicePreview.appBuilder,
+        // Initialize both FastNav and FastOverlays in one line
+        navigatorKey: FastNav.init(FastOverlays.init()),
+        navigatorObservers: [FastNavObserver()],
+        title: 'fast_ui Example',
+        theme: ThemeData.light(),
+        darkTheme: ThemeData.dark(),
+        themeMode: themeMode.value,
+        onGenerateRoute: (settings) => FastNav.generateAnonymousRoute(
+          settings: settings,
+          page: const FastUiExample(),
+        ),
+      ),
+    );
+  }
+}
+
 class FastUiExample extends StatelessWidget {
   const FastUiExample({super.key});
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(title: const Text('fast_ui Example')),
+      appBar: AppBar(title: const Text('fast_ui Example'), actions: [
+        FastBuilder(
+          () => IconButton(
+            icon: Icon(
+              themeMode.value == ThemeMode.light
+                  ? Icons.dark_mode
+                  : Icons.light_mode,
+            ),
+            onPressed: () => themeMode.value =
+                themeMode.value == ThemeMode.light
+                    ? ThemeMode.dark
+                    : ThemeMode.light,
+          ),
+        ),
+      ]),
       body: Center(
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,

--- a/fast_ui/example/pubspec.lock
+++ b/fast_ui/example/pubspec.lock
@@ -98,7 +98,7 @@ packages:
       path: "../../fast_rx_persistence"
       relative: true
     source: path
-    version: "0.1.5"
+    version: "0.2.0"
   fast_rx_shared_preferences:
     dependency: "direct main"
     description:
@@ -167,7 +167,7 @@ packages:
       name: font_awesome_flutter
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "10.2.1"
+    version: "10.3.0"
   freezed_annotation:
     dependency: transitive
     description:
@@ -307,7 +307,7 @@ packages:
       name: provider
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.4"
+    version: "6.0.5"
   rexios_lints:
     dependency: "direct dev"
     description:
@@ -342,7 +342,7 @@ packages:
       name: shared_preferences_linux
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   shared_preferences_macos:
     dependency: transitive
     description:
@@ -370,7 +370,7 @@ packages:
       name: shared_preferences_windows
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.1"
+    version: "2.1.2"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -424,14 +424,14 @@ packages:
       name: url_launcher
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.1.6"
+    version: "6.1.7"
   url_launcher_android:
     dependency: transitive
     description:
       name: url_launcher_android
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "6.0.21"
+    version: "6.0.22"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -487,7 +487,7 @@ packages:
       name: win32
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "3.1.1"
+    version: "3.1.3"
   xdg_directories:
     dependency: transitive
     description:


### PR DESCRIPTION
Replaces `decode` and `encode` parameters with a `converter` paramerter that takes a `FastRxPersistenceConverter`. This makes it possible to reuse conversion code, and also allows the creation of built in convenience converters for things such as enums.